### PR TITLE
Update CCenter for icms2

### DIFF
--- a/admin/msgadm.php
+++ b/admin/msgadm.php
@@ -4,6 +4,7 @@ include '../../../include/cp_header.php';
 include '../functions.php';
 include_once 'myformselect.php';
 
+$myts = icms_core_Textsanitizer::getInstance();
 $op = isset($_REQUEST['op'])?$myts->stripSlashesGPC($_REQUEST['op']):'';
 
 if (isset($_POST['store'])) {
@@ -31,7 +32,7 @@ if (isset($_POST['store'])) {
 	    $sets[] = 'mtime='.time();
 	    $res = icms::$xoopsDB->query("UPDATE ".CCMES." SET ".join(",", $sets)." WHERE msgid=".$msgid);
 	    if ($res && $touid) { // switch person in charge
-		$notification_handler =& xoops_gethandler('notification');
+		$notification_handler = icms::handler('icms_data_notification');
 		$notification_handler->subscribe('message', $msgid, 'comment', null, null, $touid);
 		$notification_handler->subscribe('message', $msgid, 'status', null, null, $touid);
 	    }

--- a/admin/myformselect.php
+++ b/admin/myformselect.php
@@ -4,11 +4,11 @@
 
 include_once 'mypagenav.php';
 
-class MyFormSelect extends XoopsFormSelect
+class MyFormSelect extends icms_form_elements_Select
 {
 
-    function MyFormSelect($caption,$name,$value=null,$size=1,$multiple=false){
-	$this->XoopsFormSelect($caption, $name, $value, $size, $multiple);
+    function __constructor($caption,$name,$value=null,$size=1,$multiple=false){
+	parent::__constructor($caption, $name, $value, $size, $multiple);
 	$this->pagenav = '';
 	$this->slab = _SEARCH;
     }

--- a/admin/mypagenav.php
+++ b/admin/mypagenav.php
@@ -2,14 +2,12 @@
 # $Id$
 # page control for priuid select
 
-include_once ICMS_ROOT_PATH.'/class/pagenav.php';
-
 define('_CC_MAX_USERS', 100);	// users/page
 
-class MyPageNav extends XoopsPageNav {
+class MyPageNav extends icms_view_PageNav {
 
-    function MyPageNav($total, $items, $current, $name="start", $target='uid') {
-	$this->XoopsPageNav($total, $items, $current, $name);
+    function __construct($total, $items, $current, $name="start", $target='uid') {
+	parent::__construct($total, $items, $current, $name);
 	$this->target = $target;
     }
 
@@ -69,4 +67,3 @@ function cc_group_users($group=0, $max=_CC_MAX_USERS, $start=0, $count=false) {
     }
     return $options;
 }
-?>


### PR DESCRIPTION
Make the necessary changes to let ccenter work on ImpressCMS 2 and PHP 8.3 - (8.4?)
